### PR TITLE
(fix): Set @epic-web/cachified peer dependency to ^5.1.1

### DIFF
--- a/.changeset/blue-owls-raise.md
+++ b/.changeset/blue-owls-raise.md
@@ -1,0 +1,6 @@
+---
+"cachified-adapter-cloudflare-kv": minor
+---
+
+Set @epic-web/cachified peer dependency to ^5.1.1
+This is necessary as this package uses updated type definitions from @epic-web/cachified that were introduced in `5.1.1`

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240208.0",
-    "@epic-web/cachified": "^5.0.0"
+    "@epic-web/cachified": "^5.1.1"
   },
   "peerDependenciesMeta": {
     "@cloudflare/workers-types": {


### PR DESCRIPTION
This is necessary as this package uses updated type definitions from @epic-web/cachified that were introduced in `5.1.1`